### PR TITLE
Fixed precision of clones. now moves exactly like player. Fixes #10

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -975,5 +975,10 @@ PrefabInstance:
       propertyPath: timeTravelManager
       value: 
       objectReference: {fileID: 1542336391}
+    - target: {fileID: 6557204297891356254, guid: 2da52b95146225b4585b0f531f196d4b,
+        type: 3}
+      propertyPath: positionPollFrequency
+      value: 0.1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2da52b95146225b4585b0f531f196d4b, type: 3}

--- a/Assets/Scripts/Player/CharacterMovement.cs
+++ b/Assets/Scripts/Player/CharacterMovement.cs
@@ -29,7 +29,7 @@ public class CharacterMovement : MonoBehaviour
         controller = GetComponent<IControlManager>();
     }
 
-    void FixedUpdate() {
+    void Update() {
         //Terminal velocity
         if (body.velocity.y < -terminalVelocity)
             body.velocity = new Vector2(body.velocity.x, -terminalVelocity);

--- a/Assets/Scripts/Player/CloneControlManager.cs
+++ b/Assets/Scripts/Player/CloneControlManager.cs
@@ -113,19 +113,25 @@ public class CloneControlManager : MonoBehaviour, IControlManager {
      */
     private IEnumerator PerformEvent(InputEvent inputEvent) {
         yield return new WaitForSeconds(inputEvent.startTime);
-        isPressed[(int)inputEvent.buttonEnum] = true;
-        isDown[(int)inputEvent.buttonEnum] = true;
 
-        yield return new WaitForSeconds(Time.fixedDeltaTime);
-        isDown[(int)inputEvent.buttonEnum] = false;
+        if(inputEvent.isPositionPoll) {
+            transform.position = inputEvent.pos;
+            GetComponent<Rigidbody2D>().velocity = inputEvent.vel;
+        }
 
-        yield return new WaitForSeconds(inputEvent.durationTime - Time.fixedDeltaTime);
-        isPressed[(int)inputEvent.buttonEnum] = false;
-        isUp[(int)inputEvent.buttonEnum] = true;
+        else {
+            isPressed[(int)inputEvent.buttonEnum] = true;
+            isDown[(int)inputEvent.buttonEnum] = true;
 
-        yield return new WaitForSeconds(Time.fixedDeltaTime);
-        isUp[(int)inputEvent.buttonEnum] = false;
+            yield return null;
+            isDown[(int)inputEvent.buttonEnum] = false;
 
-        yield return null;
+            yield return new WaitForSeconds(inputEvent.durationTime - Time.deltaTime);
+            isPressed[(int)inputEvent.buttonEnum] = false;
+            isUp[(int)inputEvent.buttonEnum] = true;
+
+            yield return null;
+            isUp[(int)inputEvent.buttonEnum] = false;
+        }
     }
 }

--- a/Assets/Scripts/Player/InputEvent.cs
+++ b/Assets/Scripts/Player/InputEvent.cs
@@ -10,18 +10,32 @@ public class InputEvent {
     public float startTime;
     public float durationTime;
     public Button buttonEnum;
+    public bool isPositionPoll;
+    public Vector3 pos;
+    public Vector3 vel;
 
     public InputEvent(Button buttonEnum) {
         this.buttonEnum = buttonEnum;
+        isPositionPoll = false;
     }
 
-    public InputEvent(float startTime, float durationTime, Button buttonEnum) {
+    public InputEvent(float startTime, Vector3 pos, Vector3 vel) {
         this.startTime = startTime;
-        this.durationTime = durationTime;
-        this.buttonEnum = buttonEnum;
+        this.pos = pos;
+        this.vel = vel;
+        isPositionPoll = true;
+    }
+
+    public InputEvent(InputEvent other) {
+        startTime = other.startTime;
+        durationTime = other.durationTime;
+        buttonEnum = other.buttonEnum;
+        isPositionPoll = other.isPositionPoll;
+        pos = new Vector3(other.pos.x, other.pos.y, other.pos.z);
+        vel = new Vector3(other.vel.x, other.vel.y, other.vel.z);
     }
 
     public InputEvent Clone() {
-        return new InputEvent(startTime, durationTime, buttonEnum);
+        return new InputEvent(this);
     }
 }

--- a/Assets/Scripts/Player/MovementRecorder.cs
+++ b/Assets/Scripts/Player/MovementRecorder.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class MovementRecorder : MonoBehaviour {
+
+    [SerializeField] private float positionPollFrequency;
 
     private float runTime;
     private InputButton[] inputButtons;
@@ -19,11 +22,13 @@ public class MovementRecorder : MonoBehaviour {
         for (int i = 0; i < activeInputEvents.Length; i++) {
             activeInputEvents[i] = new InputEvent((Button)i);
         }
+
+        StartCoroutine(PositionPoll());
     }
 
-    void FixedUpdate() {
+    void Update() {
         // update runtime
-        runTime += Time.fixedDeltaTime;
+        runTime += Time.deltaTime;
 
         // check status of each button for the current update
         for (int i = 0; i < inputButtons.Length; i++) {
@@ -36,7 +41,7 @@ public class MovementRecorder : MonoBehaviour {
 
             // if button is currently beeing pressed, then update duration time
             else if (inputButtons[i].GetButton()) {
-                activeInputEvents[i].durationTime += Time.fixedDeltaTime;
+                activeInputEvents[i].durationTime += Time.deltaTime;
             }
 
             // if button just stopped beeing pressed, then save the input event to the list
@@ -77,5 +82,14 @@ public class MovementRecorder : MonoBehaviour {
         }
 
         return inputEvents;
+    }
+
+    private IEnumerator PositionPoll() {
+        while (true) {
+            yield return new WaitForSeconds(positionPollFrequency);
+            Vector3 pos = transform.position;
+            Vector3 vel = GetComponent<Rigidbody2D>().velocity;
+            recordedInputEvents.AddLast(new InputEvent(runTime, new Vector3(pos.x, pos.y, pos.z), new Vector3(vel.x, vel.y, vel.z)));
+        }
     }
 }

--- a/Assets/Scripts/Player/PlayerControlManager.cs
+++ b/Assets/Scripts/Player/PlayerControlManager.cs
@@ -39,7 +39,7 @@ public class PlayerControlManager : MonoBehaviour, IControlManager {
         resetTimeButton = new InputButton(resetTime);
     }
 
-    void FixedUpdate () {
+    void Update () {
         leftButton.Update();
         rightButton.Update();
         upButton.Update();


### PR DESCRIPTION
Fixed by changing all "FixedUpdate" calls to "Update" calls, since it increased precision by a large margin.
However, since it still was not perfect, we now save position and velocity data from the player as input events each 0.1 second (as a initial value, can easily be changed later if needed.)
This makes the clone move in the exact same way as the player, and will always end up in the same end position.