### PR TITLE
Fixed door and button so that doors can be default open Fixes #15

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -772,6 +772,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Door
       objectReference: {fileID: 0}
+    - target: {fileID: 926518431577690914, guid: 97106f11b49dbbe439a86ec630b679bf,
+        type: 3}
+      propertyPath: isOn
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 926518431577690943, guid: 97106f11b49dbbe439a86ec630b679bf,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -901,6 +906,11 @@ PrefabInstance:
       propertyPath: switchable
       value: 
       objectReference: {fileID: 2134299599}
+    - target: {fileID: 3926431468490683868, guid: 129bc08d0afcd7947a13917777415c30,
+        type: 3}
+      propertyPath: permanent
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 129bc08d0afcd7947a13917777415c30, type: 3}
 --- !u!1001 &5635826309942290659
@@ -978,7 +988,7 @@ PrefabInstance:
     - target: {fileID: 6557204297891356254, guid: 2da52b95146225b4585b0f531f196d4b,
         type: 3}
       propertyPath: positionPollFrequency
-      value: 0.1
+      value: 0.01
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2da52b95146225b4585b0f531f196d4b, type: 3}

--- a/Assets/Scripts/Obstacles/Switchables/Door.cs
+++ b/Assets/Scripts/Obstacles/Switchables/Door.cs
@@ -7,7 +7,9 @@ public class Door : SwitchableSystem
     // Start is called before the first frame update
     void Start()
     {
-        
+        //If door open as default
+        if (isOn)
+            gameObject.SetActive(false); //TODO change sprite etc, not deactivate object.
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/Obstacles/Switches/ButtonSwitch.cs
+++ b/Assets/Scripts/Obstacles/Switches/ButtonSwitch.cs
@@ -23,13 +23,13 @@ public class ButtonSwitch : SwitchSystem
 
     protected override void ActivateSwitch() {
         activated = true;
-        switchable.SwitchTo(true);
+        switchable.Switch();
         //TODO add animation and SFX
     }
 
     protected override void DeactivateSwitch() {
         activated = false;
-        switchable.SwitchTo(false);
+        switchable.Switch();
         //TODO add animation and SFX
     }
 


### PR DESCRIPTION
I changed a couple lines of code so that the door can be open by default and the button will close the door instead of open it. There is a bool on the door object that can be changed in the editor: if isOn is true then the door will be open by default.