### PR TITLE
Clones can no longer phase through walls or eachother. Fixes #17

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -1,5 +1,35 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &483602266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 483602267}
+  m_Layer: 9
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &483602267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483602266}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.4, y: 0.4, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5635826310379369545}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5635826310379369547
 GameObject:
   m_ObjectHideFlags: 0
@@ -33,7 +63,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 483602267}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -150,7 +181,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b77c49cfa4ced3249bf50e7e02e845b8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  positionPollFrequency: 0
+  positionPollFrequency: 0.05
 --- !u!114 &3068179078355223741
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -221,5 +252,5 @@ MonoBehaviour:
   jump: 32
   jumpAlt: 273
   resetTime: 114
-  solidify: 0
+  solidify: 113
   joyStickDeadZone: 0.5

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -227,45 +227,9 @@ Transform:
   m_Father: {fileID: 1507060364}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &483602266
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 483602267}
-  m_Layer: 9
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &483602267
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 483602266}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.4, y: 0.4, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 505371824}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &505371816 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5635826310379369547, guid: 2da52b95146225b4585b0f531f196d4b,
-    type: 3}
-  m_PrefabInstance: {fileID: 5635826309942290659}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &505371824 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5635826310379369545, guid: 2da52b95146225b4585b0f531f196d4b,
     type: 3}
   m_PrefabInstance: {fileID: 5635826309942290659}
   m_PrefabAsset: {fileID: 0}
@@ -1021,15 +985,5 @@ PrefabInstance:
       propertyPath: timeTravelManager
       value: 
       objectReference: {fileID: 1542336391}
-    - target: {fileID: 6557204297891356254, guid: 2da52b95146225b4585b0f531f196d4b,
-        type: 3}
-      propertyPath: positionPollFrequency
-      value: 0.05
-      objectReference: {fileID: 0}
-    - target: {fileID: 104869223437697638, guid: 2da52b95146225b4585b0f531f196d4b,
-        type: 3}
-      propertyPath: solidify
-      value: 113
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2da52b95146225b4585b0f531f196d4b, type: 3}

--- a/Assets/Scripts/Player/InputEvent.cs
+++ b/Assets/Scripts/Player/InputEvent.cs
@@ -10,29 +10,27 @@ public class InputEvent {
     public float startTime;
     public float durationTime;
     public Button buttonEnum;
-    public bool isPositionPoll;
-    public Vector3 pos;
-    public Vector3 vel;
+    public bool isMovementState;
+    public MovementState movementState;
 
     public InputEvent(Button buttonEnum) {
         this.buttonEnum = buttonEnum;
-        isPositionPoll = false;
+        isMovementState = false;
     }
 
-    public InputEvent(float startTime, Vector3 pos, Vector3 vel) {
+    public InputEvent(float startTime, MovementState movementState) {
         this.startTime = startTime;
-        this.pos = pos;
-        this.vel = vel;
-        isPositionPoll = true;
+        this.movementState = movementState;
+        isMovementState = true;
     }
 
     public InputEvent(InputEvent other) {
         startTime = other.startTime;
         durationTime = other.durationTime;
         buttonEnum = other.buttonEnum;
-        isPositionPoll = other.isPositionPoll;
-        pos = new Vector3(other.pos.x, other.pos.y, other.pos.z);
-        vel = new Vector3(other.vel.x, other.vel.y, other.vel.z);
+        isMovementState = other.isMovementState;
+        if(other.isMovementState)
+            movementState = new MovementState(other.movementState);
     }
 
     public InputEvent Clone() {

--- a/Assets/Scripts/Player/MovementRecorder.cs
+++ b/Assets/Scripts/Player/MovementRecorder.cs
@@ -88,9 +88,7 @@ public class MovementRecorder : MonoBehaviour {
     private IEnumerator PositionPoll() {
         while (true) {
             yield return new WaitForSeconds(positionPollFrequency);
-            Vector3 pos = transform.position;
-            Vector3 vel = GetComponent<Rigidbody2D>().velocity;
-            recordedInputEvents.AddLast(new InputEvent(runTime, new Vector3(pos.x, pos.y, pos.z), new Vector3(vel.x, vel.y, vel.z)));
+            recordedInputEvents.AddLast(new InputEvent(runTime, new MovementState(gameObject)));
         }
     }
 }

--- a/Assets/Scripts/Player/MovementState.cs
+++ b/Assets/Scripts/Player/MovementState.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+
+public class MovementState {
+    public Vector3 pos;
+    public Vector3 vel;
+    public bool isGroundUp;
+    public bool isGroundDown;
+    public bool isGroundRight;
+    public bool isGroundLeft;
+
+    public MovementState(GameObject gameObject) {
+        Rigidbody2D rigidbody = gameObject.GetComponent<Rigidbody2D>();
+        pos = new Vector3(rigidbody.position.x, rigidbody.position.y, 0);
+        vel = new Vector3(rigidbody.velocity.x, rigidbody.velocity.y, 0);
+
+        CollisionAnalysis collisionAnalysis = gameObject.GetComponent<CollisionAnalysis>();
+        isGroundUp = collisionAnalysis.IsGroundUp();
+        isGroundDown = collisionAnalysis.IsGroundDown();
+        isGroundRight = collisionAnalysis.IsGroundRight();
+        isGroundLeft = collisionAnalysis.IsGroundLeft();
+    }
+
+    public MovementState(MovementState state) {
+        pos = new Vector3(state.pos.x, state.pos.y, state.pos.z);
+        vel = new Vector3(state.vel.x, state.vel.y, state.vel.z);
+        isGroundUp = state.isGroundUp;
+        isGroundDown = state.isGroundDown;
+        isGroundRight = state.isGroundRight;
+        isGroundLeft = state.isGroundLeft;
+    }
+}

--- a/Assets/Scripts/Player/MovementState.cs.meta
+++ b/Assets/Scripts/Player/MovementState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b966b32021b3c74597c529600326895
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Clones can no longer phase through something that is not possible anymore.
The issue is fixed by saving the current state for each poll on the player.
If the state on the clone does not match up with the saved state of the player, syncing will be disabled for the current run (e.g. if clone collides with something at a certain point in time, and player did not.)