### PR TITLE
Camera goes back to the checkpoint when resetting Fixes #69

### DIFF
--- a/Assets/Scripts/Camera/CameraManager.cs
+++ b/Assets/Scripts/Camera/CameraManager.cs
@@ -39,4 +39,8 @@ public class CameraManager: MonoBehaviour
     public void SetPivot(Transform pivot) {
         roomPivot = pivot;
     }
+
+    public Transform GetPivot() {
+        return roomPivot;
+    }
 }

--- a/Assets/Scripts/Checkpoint/CheckpointManager.cs
+++ b/Assets/Scripts/Checkpoint/CheckpointManager.cs
@@ -12,6 +12,7 @@ public class CheckpointManager : MonoBehaviour
     [SerializeField] private Checkpoint startingCheckpoint;
 
     private Checkpoint activeCheckpoint;
+    private Transform activeCheckpointPivot;
     private Dictionary<Checkpoint, List<GameObject>> clones; //Dictionary of checkpoints and all clones that belong to each one
 
     public static CheckpointManager Instance { get { return instance; } }
@@ -37,6 +38,7 @@ public class CheckpointManager : MonoBehaviour
     //Set active checkpoint and create a List of clones for that checkpoint if none exists
     public void SetActiveCheckpoint(Checkpoint checkpoint) {
         activeCheckpoint = checkpoint;
+        activeCheckpointPivot = CameraManager.Instance.GetPivot();
         if (!clones.ContainsKey(activeCheckpoint))
             clones.Add(activeCheckpoint, new List<GameObject>());
     }
@@ -65,5 +67,9 @@ public class CheckpointManager : MonoBehaviour
     //Gets the active checkpoint
     public Checkpoint GetActiveCheckpoint() {
         return activeCheckpoint;
+    }
+
+    public Transform GetCheckpointPivot() {
+        return activeCheckpointPivot;
     }
 }

--- a/Assets/Scripts/Player/TimeTravelManager.cs
+++ b/Assets/Scripts/Player/TimeTravelManager.cs
@@ -66,6 +66,9 @@ public class TimeTravelManager: MonoBehaviour
             s.ResetSwitchable();
         }
 
+        //Reset Camera
+        CameraManager.Instance.SetPivot(CheckpointManager.Instance.GetCheckpointPivot());
+
         // reset position and velocities of player
         player.GetComponent<CharacterMovement> ().ResetCharacter();
         movementRecorder.ResetRecording();


### PR DESCRIPTION
If you switch pivot point without touching a checkpoint and reset, the pivot will be switched back to the pivot you had when you touched the checkpoint.