### PR TITLE
You can no longer brute force turrets Fixes #76

### DIFF
--- a/Assets/Scripts/Obstacles/Switchables/Turret.cs
+++ b/Assets/Scripts/Obstacles/Switchables/Turret.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class Turret : SwitchableSystem
 {
-    [SerializeField] private float maxDistance;
+    [SerializeField] private float maxDistance; //The laser will go this far regardless of what it hits
     [SerializeField] private GameObject laser;
     [Space]
     [SerializeField] private bool steadyFire; //Is the turret shooting a constant laser?
@@ -28,19 +28,17 @@ public class Turret : SwitchableSystem
         timeElapsed += Time.deltaTime;
         if (steadyFire || (timeElapsed > shotDelay && timeElapsed <= shotDelay + shotDuration)) {
             laser.SetActive(true);
-            RaycastHit2D hit = Physics2D.Raycast(transform.position, transform.right, maxDistance, LayerMask.GetMask("Character") | LayerMask.GetMask("Ground"));
-            Vector2 end;
-            if (hit.collider != null) {
-                end = hit.point;
-                if (hit.collider.gameObject.layer == 9) {
-                    hit.collider.gameObject.GetComponent<CharacterMovement>().Die();
-                }
-            } else {
-                end = transform.position + transform.right * maxDistance;
+            List<RaycastHit2D> hits = new List<RaycastHit2D>();
+            ContactFilter2D filter = new ContactFilter2D();
+            filter.SetLayerMask(LayerMask.GetMask("Character"));
+            Physics2D.Raycast(transform.position, transform.right, filter, hits, maxDistance);
+            foreach (RaycastHit2D hit in hits) {
+                hit.collider.gameObject.GetComponent<CharacterMovement>().Die();
             }
 
             //Draw laser
-            laser.GetComponent<Laser>().SetUpLaser(transform.position, end, hit.collider != null);
+            Vector2 end = transform.position + transform.right * maxDistance;
+            laser.GetComponent<Laser>().SetUpLaser(transform.position, end);
         }
         if(!steadyFire) {
             if (timeElapsed < shotDelay)

--- a/Assets/Scripts/Player/CharacterMovement.cs
+++ b/Assets/Scripts/Player/CharacterMovement.cs
@@ -152,11 +152,11 @@ public class CharacterMovement : MonoBehaviour
                     hit.collider.gameObject.SetActive(false);
                 }
                 GameObject currentLaser = Instantiate(laser);
-                currentLaser.GetComponent<Laser>().SetUpLaser(origin, hit.point, true);
+                currentLaser.GetComponent<Laser>().SetUpLaser(origin, hit.point);
                 Destroy(currentLaser, laserDuration);
             } else {
                 GameObject currentLaser = Instantiate(laser);
-                currentLaser.GetComponent<Laser>().SetUpLaser(origin, origin + forwardVector * shotDistance, false);
+                currentLaser.GetComponent<Laser>().SetUpLaser(origin, origin + forwardVector * shotDistance);
                 Destroy(currentLaser, laserDuration);
             }
             //Play SFX

--- a/Assets/Scripts/VFX/Laser.cs
+++ b/Assets/Scripts/VFX/Laser.cs
@@ -11,7 +11,7 @@ public class Laser : MonoBehaviour
 
     private LineRenderer line;
 
-    public void SetUpLaser (Vector3 startPoint, Vector3 endPoint, bool hit) {
+    public void SetUpLaser (Vector3 startPoint, Vector3 endPoint) {
         this.startPoint = startPoint;
         this.endPoint = endPoint;
         line = GetComponent<LineRenderer>();


### PR DESCRIPTION
You can no longer brute force the lasers by creating an "umbrella" of clones.
Turret lases will now go the distance specified regardless of what it hits, so level designers must take this into account when setting up lasers.