### PR TITLE
Second Camera mode that follows player Fixes #70

### DIFF
--- a/Assets/Scripts/Camera/PivotSwitch.cs
+++ b/Assets/Scripts/Camera/PivotSwitch.cs
@@ -4,10 +4,12 @@ using UnityEngine;
 
 public class PivotSwitch : MonoBehaviour
 {
+    [SerializeField] private bool playerPivot;
 
     void OnTriggerEnter2D(Collider2D other) {
         if (other.tag == "Player") {
-            CameraManager.Instance.SetPivot(transform.parent);
+            Transform newPivot = (playerPivot) ? other.transform : transform.parent;
+            CameraManager.Instance.SetPivot(newPivot);
         }
     }
 }


### PR DESCRIPTION
On ever pivotSwitch there is a bool in the editor that if checked will make the player the pivot so the camera will follow the player only.