### PR TITLE
Added controller support WINDOWS Fixes #54

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -296,11 +296,15 @@ MonoBehaviour:
   up: 119
   down: 115
   jump: 32
-  jumpAlt: 273
+  jumpAlt: 330
   resetTime: 114
+  resetTimeAlt: 332
   solidify: 113
+  solidifyAlt: 331
   clear: 101
+  clearAlt: 333
   shoot: 99
+  shootAlt: 335
   joyStickDeadZone: 0.5
 --- !u!114 &-3665093496600302557
 MonoBehaviour:

--- a/Assets/Scenes/FirstLevel.unity
+++ b/Assets/Scenes/FirstLevel.unity
@@ -156,7 +156,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 78222722}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.07578671, y: 2.0619636, z: -17.535156}
+  m_LocalPosition: {x: 0, y: 0, z: -17.535156}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1517257716}
@@ -4468,7 +4468,7 @@ PrefabInstance:
     - target: {fileID: 1210215233403434463, guid: 6343dc11a6f9beb4fa5ca225fd74502d,
         type: 3}
       propertyPath: maxDistance
-      value: 11
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1210215233403434460, guid: 6343dc11a6f9beb4fa5ca225fd74502d,
         type: 3}
@@ -4478,7 +4478,7 @@ PrefabInstance:
     - target: {fileID: 1210215233403434460, guid: 6343dc11a6f9beb4fa5ca225fd74502d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.5
+      value: 2.67
       objectReference: {fileID: 0}
     - target: {fileID: 1210215233403434460, guid: 6343dc11a6f9beb4fa5ca225fd74502d,
         type: 3}
@@ -4552,7 +4552,7 @@ Grid:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 789361800}
   m_Enabled: 1
-  m_CellSize: {x: 1, y: 1, z: 0}
+  m_CellSize: {x: 0.5, y: 0.5, z: 0}
   m_CellGap: {x: 0, y: 0, z: 0}
   m_CellLayout: 0
   m_CellSwizzle: 0
@@ -8480,12 +8480,12 @@ PrefabInstance:
     - target: {fileID: 5635826310379369545, guid: 2da52b95146225b4585b0f531f196d4b,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.5
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 5635826310379369545, guid: 2da52b95146225b4585b0f531f196d4b,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -4.5
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 5635826310379369545, guid: 2da52b95146225b4585b0f531f196d4b,
         type: 3}
@@ -9062,12 +9062,12 @@ PrefabInstance:
     - target: {fileID: 3926431468490683864, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.5
+      value: -2.7
       objectReference: {fileID: 0}
     - target: {fileID: 3926431468490683864, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -5.84
+      value: -2.84
       objectReference: {fileID: 0}
     - target: {fileID: 3926431468490683864, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
@@ -9116,7 +9116,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3926431468490683868, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
+      propertyPath: switchables.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3926431468490683868, guid: 129bc08d0afcd7947a13917777415c30,
+        type: 3}
       propertyPath: switchable
+      value: 
+      objectReference: {fileID: 790954267}
+    - target: {fileID: 3926431468490683868, guid: 129bc08d0afcd7947a13917777415c30,
+        type: 3}
+      propertyPath: switchables.Array.data[0]
       value: 
       objectReference: {fileID: 790954267}
     m_RemovedComponents: []
@@ -9295,6 +9305,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.y
       value: 15
       objectReference: {fileID: 0}
+    - target: {fileID: 3909242435081524829, guid: 504f5161b86b9194ea9e76ed6a135085,
+        type: 3}
+      propertyPath: playerPivot
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 504f5161b86b9194ea9e76ed6a135085, type: 3}
 --- !u!1001 &1995772577
@@ -9312,12 +9327,12 @@ PrefabInstance:
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.5757867
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -6.5619636
+      value: -2
       objectReference: {fileID: 0}
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}
@@ -9387,7 +9402,7 @@ PrefabInstance:
     - target: {fileID: 3926431468490683864, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 46.5
+      value: 46.76
       objectReference: {fileID: 0}
     - target: {fileID: 3926431468490683864, guid: 129bc08d0afcd7947a13917777415c30,
         type: 3}
@@ -9540,12 +9555,12 @@ PrefabInstance:
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 36.42
+      value: 23.1
       objectReference: {fileID: 0}
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -6.5619636
+      value: -2.99
       objectReference: {fileID: 0}
     - target: {fileID: 6501169077847853055, guid: 20e9b635bc870f44f8367ea96638ccb4,
         type: 3}

--- a/Assets/Scripts/Player/ControlManager.cs
+++ b/Assets/Scripts/Player/ControlManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
  * Enum keeping track of all buttons, nrButtons is how many registered buttons there is in total (it has to be last!)
  */
 public enum Button {
-    left, right, up, down, jump, jumpAlt, resetTime, solidify, clear, shoot, nrButtons
+    left, right, up, down, jump, jumpAlt, resetTime, resetTimeAlt, solidify, solidifyAlt, clear, clearAlt, shoot, shootAlt, nrButtons
 }
 
 public class ControlManager : MonoBehaviour {
@@ -21,9 +21,13 @@ public class ControlManager : MonoBehaviour {
     [SerializeField] private KeyCode jump;
     [SerializeField] private KeyCode jumpAlt;
     [SerializeField] private KeyCode resetTime;
+    [SerializeField] private KeyCode resetTimeAlt;
     [SerializeField] private KeyCode solidify;
+    [SerializeField] private KeyCode solidifyAlt;
     [SerializeField] private KeyCode clear;
+    [SerializeField] private KeyCode clearAlt;
     [SerializeField] private KeyCode shoot;
+    [SerializeField] private KeyCode shootAlt;
 
     [SerializeField] private float joyStickDeadZone = 0.5f;
 
@@ -36,7 +40,7 @@ public class ControlManager : MonoBehaviour {
     void Awake() {
         syncMovementState = true;
         analyser = GetComponent<CollisionAnalysis>();
-        keyCodes = new KeyCode[] { left, right, up, down, jump, jumpAlt, resetTime, solidify, clear, shoot };
+        keyCodes = new KeyCode[] { left, right, up, down, jump, jumpAlt, resetTime, resetTimeAlt, solidify, solidifyAlt, clear, clearAlt, shoot, shootAlt };
         inputButtons = new InputButton[(int)Button.nrButtons];
         
 
@@ -54,6 +58,12 @@ public class ControlManager : MonoBehaviour {
      * Update function will only be called if this gameObject is player (enabled is set to false otherwise)
      */
     void Update() {
+        //Force directional buttons from controller axis
+        inputButtons[(int)Button.left].SetForcePress(Input.GetAxisRaw("LeftStickX") < -joyStickDeadZone);
+        inputButtons[(int)Button.right].SetForcePress(Input.GetAxisRaw("LeftStickX") > joyStickDeadZone);
+        inputButtons[(int)Button.up].SetForcePress(Input.GetAxisRaw("LeftStickY") > joyStickDeadZone);
+        inputButtons[(int)Button.down].SetForcePress(Input.GetAxisRaw("LeftStickY") < -joyStickDeadZone);
+
         for (int i = 0; i < (int)Button.nrButtons; i++) {
             inputButtons[i].Update();
         }
@@ -132,28 +142,28 @@ public class ControlManager : MonoBehaviour {
     * Returns bool for reset time button event
     */
     public bool ResetButtonUp() {
-        return inputButtons[(int)Button.resetTime].GetButtonUp();
+        return inputButtons[(int)Button.resetTime].GetButtonUp() || inputButtons[(int)Button.resetTimeAlt].GetButtonUp();
     }
 
     /**
      * Returns bool for Solidify button down event
      */
      public bool SolidifyButtonDown() {
-        return inputButtons[(int)Button.solidify].GetButtonDown();
+        return inputButtons[(int)Button.solidify].GetButtonDown() || inputButtons[(int)Button.solidifyAlt].GetButtonDown();
      }
 
     /**
      * Returns bool for Clear button down event
      */
     public bool ClearButtonDown() {
-        return inputButtons[(int)Button.clear].GetButtonDown();
+        return inputButtons[(int)Button.clear].GetButtonDown() || inputButtons[(int)Button.clearAlt].GetButtonDown();
     }
 
     /**
      * Returns bool for Shoot button down event
      */
     public bool ShootButtonDown() {
-        return inputButtons[(int)Button.shoot].GetButtonDown();
+        return inputButtons[(int)Button.shoot].GetButtonDown() || inputButtons[(int)Button.shootAlt].GetButtonDown();
     }
 
     /**

--- a/Assets/Scripts/Player/InputButton.cs
+++ b/Assets/Scripts/Player/InputButton.cs
@@ -11,6 +11,7 @@ public class InputButton {
     private bool pressed;
     private bool buttonDown;
     private bool buttonUp;
+    private bool forcePressed;
 
 
     public InputButton(KeyCode button) {
@@ -19,20 +20,20 @@ public class InputButton {
     }
 
     public void Update() {
-        if (Input.GetKey(button) && pressed) {
+        if ((Input.GetKey(button) || forcePressed) && pressed) {
             buttonDown = false;
         }
 
-        if (Input.GetKey(button) && !pressed) { //Button down event
+        if ((Input.GetKey(button) || forcePressed) && !pressed) { //Button down event
             buttonDown = true;
             pressed = true;
         }
 
-        if (!Input.GetKey(button) && !pressed) {
+        if (!(Input.GetKey(button) || forcePressed) && !pressed) {
             buttonUp = false;
         }
 
-        if (!Input.GetKey(button) && pressed) { //Button up event
+        if (!(Input.GetKey(button) || forcePressed) && pressed) { //Button up event
             buttonUp = true;
             pressed = false;
         }
@@ -64,5 +65,9 @@ public class InputButton {
 
     public KeyCode GetKeyCode() {
         return button;
+    }
+
+    public void SetForcePress(bool to) {
+        forcePressed = to;
     }
 }


### PR DESCRIPTION
The xbox controller works for windows now (for some reason mac and windows have different keybindings for xbox controls).
A-button is jump
B-button is solidify
X-button is reset
Y-button is clear clones at checkpoint
RB is shoot

It worked plug and play with my SNES controller too, but the button mappings were a little strange (easy to change though so we could set it up right before the demo if we wanted).