### PR TITLE
Now you can easily add stuff to balance splitter!

### DIFF
--- a/Assets/Scripts/Obstacles/Switches/BalanceSwitch/BalanceSplitter.cs
+++ b/Assets/Scripts/Obstacles/Switches/BalanceSwitch/BalanceSplitter.cs
@@ -14,18 +14,18 @@ public class BalanceSplitter : BalanceComponent
     // Start is called before the first frame update
     void Awake()
     {
-        left = transform.GetChild(0).GetComponent<BalanceComponent> ();
-        right = transform.GetChild(1).GetComponent<BalanceComponent> ();
+        left = transform.GetChild(5).GetComponent<BalanceComponent> ();
+        right = transform.GetChild(6).GetComponent<BalanceComponent> ();
 
-        transform.GetChild(2).transform.localPosition = new Vector3(left.transform.localPosition.x, 0, 0);
-        transform.GetChild(4).transform.localPosition = new Vector3(left.transform.localPosition.x / 2, 0, 0);
-        transform.GetChild(4).GetComponent<SpriteRenderer>().size = new Vector2(Mathf.Abs(left.transform.localPosition.x), 1);
+        transform.GetChild(0).transform.localPosition = new Vector3(left.transform.localPosition.x, 0, 0);
+        transform.GetChild(2).transform.localPosition = new Vector3(left.transform.localPosition.x / 2, 0, 0);
+        transform.GetChild(2).GetComponent<SpriteRenderer>().size = new Vector2(Mathf.Abs(left.transform.localPosition.x), 1);
 
-        transform.GetChild(3).transform.localPosition = new Vector3(right.transform.localPosition.x, 0, 0);
-        transform.GetChild(5).transform.localPosition = new Vector3(right.transform.localPosition.x / 2, 0, 0);
-        transform.GetChild(5).GetComponent<SpriteRenderer>().size = new Vector2(Mathf.Abs(right.transform.localPosition.x), 1);
+        transform.GetChild(1).transform.localPosition = new Vector3(right.transform.localPosition.x, 0, 0);
+        transform.GetChild(3).transform.localPosition = new Vector3(right.transform.localPosition.x / 2, 0, 0);
+        transform.GetChild(3).GetComponent<SpriteRenderer>().size = new Vector2(Mathf.Abs(right.transform.localPosition.x), 1);
 
-        chain = transform.GetChild(6).gameObject;
+        chain = transform.GetChild(4).gameObject;
 
         if (IsFulfilled()) GetComponent<Animator>().Play("active");
         else GetComponent<Animator>().Play("deactive");


### PR DESCRIPTION
The components added to the balance splitter are added at the bottom instead of top now. This is to avoid unpacking prefabs :)